### PR TITLE
Added higher abstraction Motor Control Class

### DIFF
--- a/pyvesc/VESCMotor.py
+++ b/pyvesc/VESCMotor.py
@@ -1,0 +1,181 @@
+import pyvesc
+from pyvesc import *
+import time
+import threading
+
+# because people may want to use this library for their own messaging, do not make this a required package
+try:
+    import serial
+except ImportError:
+    serial = None
+
+
+class VESCMotor(object):
+    def __init__(self, serial_port, has_sensor=False, start_heartbeat=True, baudrate=115200, timeout=0.05):
+        """
+        :param serial_port: Serial device to use for communication (i.e. "COM3" or "/dev/tty.usbmodem0")
+        :param has_sensor: Whether or not the bldc motor is using a hall effect sensor
+        :param start_heartbeat: Whether or not to automatically start the heartbeat thread that will keep commands
+                                alive.
+        :param baudrate: baudrate for the serial communication. Shouldn't need to change this.
+        :param timeout: timeout for the serial communication
+        """
+
+        if serial is None:
+            raise ImportError("Need to install pyserial in order to use the VESCMotor class.")
+
+        self.serial_port = serial.Serial(port=serial_port, baudrate=baudrate, timeout=timeout)
+        if has_sensor:
+            self.serial_port.write(pyvesc.encode(SetRotorPositionMode(SetRotorPositionMode.DISP_POS_OFF)))
+
+        self.heart_beat_thread = threading.Thread(target=self._heartbeat_cmd_func)
+        self._stop_heartbeat = threading.Event()
+
+        def pass_func(value, value2):
+            pass
+
+        self._pass_func = pass_func
+        self._func_lock = threading.Lock()
+        self._last_cmd_func = pass_func
+        self._value_lock = threading.Lock()
+        self._last_cmd_value = None
+
+        if start_heartbeat:
+            self.start_heartbeat()
+
+        # check firmware version and set GetValue fields to old values if pre version 3.xx
+        version = self.get_firmware_version()
+        if int(version.split('.')[0]) < 3:
+            GetValues.fields = pre_v3_33_fields
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop_heartbeat()
+
+    @property
+    def last_cmd_func(self):
+        with self._func_lock:
+            return self._last_cmd_func
+
+    @last_cmd_func.setter
+    def last_cmd_func(self, new_func):
+        with self._func_lock:
+            self._last_cmd_func = new_func
+
+    @property
+    def last_cmd_value(self):
+        with self._value_lock:
+            return self._last_cmd_value
+
+    @last_cmd_value.setter
+    def last_cmd_value(self, new_value):
+        with self._value_lock:
+            self._last_cmd_value = new_value
+
+    def _heartbeat_cmd_func(self):
+        """
+        Continuous function calling that keeps the motor alive
+        """
+        while not self._stop_heartbeat.isSet():
+            time.sleep(0.1)
+            self.last_cmd_func(self.last_cmd_value, True)
+
+    def start_heartbeat(self):
+        """
+        Starts a repetitive calling of the last set cmd to keep the motor alive.
+        """
+        self.heart_beat_thread.start()
+
+    def stop_heartbeat(self):
+        """
+        Stops the heartbeat thread and resets the last cmd function. THIS MUST BE CALLED BEFORE THE OBJECT GOES OUT OF
+        SCOPE UNLESS WRAPPING IN A WITH STATEMENT (Assuming the heartbeat was started).
+        """
+        if self.heart_beat_thread.is_alive():
+            self._stop_heartbeat.set()
+            self.heart_beat_thread.join()
+        self.last_cmd_func = self._pass_func
+        self.last_cmd_value = None
+
+    def write(self, data, num_read_bytes=None):
+        """
+        A write wrapper function implemented like this to try and make it easier to incorporate other communication
+        methods than UART in the future.
+        :param data: the byte string to be sent
+        :param num_read_bytes: number of bytes to read for decoding response
+        :return: decoded response from buffer
+        """
+        self.serial_port.write(data)
+        if num_read_bytes is not None:
+            while self.serial_port.in_waiting <= num_read_bytes:
+                time.sleep(0.01)
+            response, consumed = pyvesc.decode(self.serial_port.read(self.serial_port.in_waiting))
+            return response
+
+    def set_rpm(self, new_rpm, _heart_beat_call=False):
+        """
+        Set the electronic RPM value (a.k.a. the RPM value of the stator)
+        :param new_rpm: new rpm value
+        :param _heart_beat_call: whether or not this function is called from the heartbeat thread
+        :return: Nothing
+        """
+        self.write(pyvesc.encode(SetRPM(new_rpm)))
+        if not _heart_beat_call:
+            self.last_cmd_func = self.set_rpm
+            self.last_cmd_value = new_rpm
+
+    def set_current(self, new_current, _heart_beat_call=False):
+        """
+        :param new_current: new current in milli-amps for the motor
+        :param _heart_beat_call: whether or not this function is called from the heartbeat thread
+        :return: Nothing
+        """
+        self.write(pyvesc.encode(SetCurrent(new_current)))
+        if not _heart_beat_call:
+            self.last_cmd_func = self.set_current
+            self.last_cmd_value = new_current
+
+    def set_duty_cycle(self, new_duty_cycle, _heart_beat_call=False):
+        """
+        :param new_duty_cycle: Value of duty cycle to be set (range [-1e5, 1e5]).
+        :param _heart_beat_call: whether or not this function is called from the heartbeat thread
+        :return: Nothing
+        """
+        self.write(pyvesc.encode(SetDutyCycle(new_duty_cycle)))
+        if not _heart_beat_call:
+            self.last_cmd_func = self.set_duty_cycle
+            self.last_cmd_value = new_duty_cycle
+
+    def get_measurements(self):
+        """
+        :return: A msg object with attributes containing the measurement values
+        """
+        msg = GetValues()
+        return self.write(pyvesc.encode_request(msg), num_read_bytes=msg._full_msg_size)
+
+    def get_firmware_version(self):
+        msg = GetVersion()
+        return str(self.write(pyvesc.encode_request(msg), num_read_bytes=msg._full_msg_size))
+
+    ''' The following methods are just to make it simpler for the user if they only want one common value from a 
+        given request. '''
+    def get_rpm(self):
+        return self.get_measurements().rpm
+
+    def get_duty_cycle(self):
+        return self.get_measurements().duty_now
+
+    def get_v_in(self):
+        return self.get_measurements().v_in
+
+    def get_motor_current(self):
+        return self.get_measurements().current_motor
+
+    def get_incoming_current(self):
+        return self.get_measurements().current_in
+
+
+
+

--- a/pyvesc/__init__.py
+++ b/pyvesc/__init__.py
@@ -1,6 +1,7 @@
 import sys
-if sys.version_info < (3,3):
+if sys.version_info < (3, 3):
     raise SystemExit("Invalid Python version. PyVESC requires Python 3.3 or greater.")
 
 from pyvesc.interface import *
 from pyvesc.messages import *
+from pyvesc.VESCMotor import VESCMotor

--- a/pyvesc/examples/motor_example.py
+++ b/pyvesc/examples/motor_example.py
@@ -1,0 +1,42 @@
+from pyvesc import VESCMotor
+import time
+
+# serial port that VESC is connected to. Something like "COM3" for windows and as below for linux/mac
+serial_port = '/dev/tty.usbmodem301'
+
+
+# a function to show how to use the class with a with-statement
+def run_motor_using_with():
+    with VESCMotor(serial_port=serial_port) as motor:
+        print("Firmware: ", motor.get_firmware_version())
+        motor.set_rpm(5000)
+
+        # run motor and print out rpm for 2 seconds
+        for _ in range(200):
+            time.sleep(0.01)
+            print(motor.get_measurements().rpm)
+        motor.set_rpm(0)
+
+
+# a function to show how to use the class as a static object.
+def run_motor_as_object():
+    motor = VESCMotor(serial_port=serial_port)
+    print("Firmware: ", motor.get_firmware_version())
+    motor.set_rpm(5000)
+
+    # run motor and print out rpm for 2 seconds
+    for _ in range(200):
+        time.sleep(0.01)
+        print(motor.get_measurements().rpm)
+    motor.set_rpm(0)
+
+    # IMPORTANT: YOU MUST STOP THE HEARTBEAT IF IT IS RUNNING BEFORE IT GOES OUT OF SCOPE. Otherwise, it will not
+    #            clean-up properly.
+    motor.stop_heartbeat()
+
+
+if __name__ == '__main__':
+    run_motor_using_with()
+    run_motor_as_object()
+
+

--- a/pyvesc/examples/motor_example.py
+++ b/pyvesc/examples/motor_example.py
@@ -11,9 +11,9 @@ def run_motor_using_with():
         print("Firmware: ", motor.get_firmware_version())
         motor.set_rpm(5000)
 
-        # run motor and print out rpm for 2 seconds
-        for _ in range(200):
-            time.sleep(0.01)
+        # run motor and print out rpm for ~2 seconds
+        for i in range(20):
+            time.sleep(0.1)
             print(motor.get_measurements().rpm)
         motor.set_rpm(0)
 
@@ -24,9 +24,9 @@ def run_motor_as_object():
     print("Firmware: ", motor.get_firmware_version())
     motor.set_rpm(5000)
 
-    # run motor and print out rpm for 2 seconds
-    for _ in range(200):
-        time.sleep(0.01)
+    # run motor and print out rpm for ~2 seconds
+    for _ in range(20):
+        time.sleep(0.1)
         print(motor.get_measurements().rpm)
     motor.set_rpm(0)
 
@@ -35,8 +35,16 @@ def run_motor_as_object():
     motor.stop_heartbeat()
 
 
+def time_get_values():
+    with VESCMotor(serial_port=serial_port) as motor:
+        start = time.time()
+        motor.get_measurements()
+        stop = time.time()
+        print("Getting values takes ", stop-start, "seconds.")
+
+
 if __name__ == '__main__':
     run_motor_using_with()
     run_motor_as_object()
-
+    time_get_values()
 

--- a/pyvesc/messages/getters.py
+++ b/pyvesc/messages/getters.py
@@ -1,30 +1,67 @@
 from pyvesc.messages.base import VESCMessage
 
+
+pre_v3_33_fields = [('temp_mos1', 'h', 10),
+                    ('temp_mos2', 'h', 10),
+                    ('temp_mos3', 'h', 10),
+                    ('temp_mos4', 'h', 10),
+                    ('temp_mos5', 'h', 10),
+                    ('temp_mos6', 'h', 10),
+                    ('temp_pcb',  'h', 10),
+                    ('current_motor', 'i', 100),
+                    ('current_in',  'i', 100),
+                    ('duty_now',    'h', 1000),
+                    ('rpm',         'i', 1),
+                    ('v_in',        'h', 10),
+                    ('amp_hours',   'i', 10000),
+                    ('amp_hours_charged', 'i', 10000),
+                    ('watt_hours',  'i', 10000),
+                    ('watt_hours_charged', 'i', 10000),
+                    ('tachometer', 'i', 1),
+                    ('tachometer_abs', 'i', 1),
+                    ('mc_fault_code', 'c', 0)]
+
+
+class GetVersion(metaclass=VESCMessage):
+    """ Gets version fields
+    """
+    id = 0
+
+    fields = [
+            ('comm_fw_version', 'b', 0),
+            ('fw_version_major', 'b', 0),
+            ('fw_version_minor', 'b', 0)
+    ]
+
+    def __str__(self):
+        return f"{self.comm_fw_version}.{self.fw_version_major}.{self.fw_version_minor}"
+
+
 class GetValues(metaclass=VESCMessage):
     """ Gets internal sensor data
     """
     id = 4
 
     fields = [
-            ('temp_mos1', 'h', 10),
-            ('temp_mos2', 'h', 10),
-            ('temp_mos3', 'h', 10),
-            ('temp_mos4', 'h', 10),
-            ('temp_mos5', 'h', 10),
-            ('temp_mos6', 'h', 10),
-            ('temp_pcb',  'h', 10),
-            ('current_motor', 'i', 100),
-            ('current_in',  'i', 100),
-            ('duty_now',    'h', 1000),
-            ('rpm',         'i', 1),
-            ('v_in',        'h', 10),
-            ('amp_hours',   'i', 10000),
-            ('amp_hours_charged', 'i', 10000),
-            ('watt_hours',  'i', 10000),
-            ('watt_hours_charged', 'i', 10000),
-            ('tachometer', 'i', 1),
-            ('tachometer_abs', 'i', 1),
-            ('mc_fault_code', 'c')
+        ('temp_fet', 'h', 10),
+        ('temp_motor', 'h', 10),
+        ('avg_motor_current', 'i', 100),
+        ('avg_input_current', 'i', 100),
+        ('avg_id', 'i', 100),
+        ('avg_iq', 'i', 100),
+        ('duty_cycle_now', 'h', 1000),
+        ('rpm', 'i', 1),
+        ('v_in', 'h', 10),
+        ('amp_hours', 'i', 10000),
+        ('amp_hours_charged', 'i', 10000),
+        ('watt_hours', 'i', 10000),
+        ('watt_hours_charged', 'i', 10000),
+        ('tachometer', 'i', 1),
+        ('tachometer_abs', 'i', 1),
+        ('mc_fault_code', 'c', 0),
+        ('pid_pos_now', 'i', 1000000),
+        ('app_controller_id', 'c', 0),
+        ('time_ms', 'i', 1),
     ]
 
 

--- a/pyvesc/packet/codec.py
+++ b/pyvesc/packet/codec.py
@@ -1,6 +1,8 @@
 from pyvesc.packet.structure import *
 from pyvesc.packet.exceptions import *
-from PyCRC.CRCCCITT import CRCCCITT
+from crccheck.crc import CrcXmodem
+
+crc_checker = CrcXmodem()
 
 
 class UnpackerBase(object):
@@ -110,7 +112,8 @@ class UnpackerBase(object):
         :param footer: Footer object
         :return: void
         """
-        if CRCCCITT().calculate(payload) != footer.crc:
+        crc_checker.calc(payload)
+        if crc_checker.calc(payload) != footer.crc:
             raise CorruptPacket("Invalid checksum value.")
         if footer.terminator is not Footer.TERMINATOR:
             raise CorruptPacket("Invalid terminator: %u" % footer.terminator)

--- a/pyvesc/packet/structure.py
+++ b/pyvesc/packet/structure.py
@@ -1,7 +1,9 @@
 import collections
 import struct
 from pyvesc.packet.exceptions import *
-from PyCRC.CRCCCITT import CRCCCITT
+from crccheck.crc import CrcXmodem
+
+crc_checker = CrcXmodem()
 
 
 class Header(collections.namedtuple('Header', ['payload_index', 'payload_length'])):
@@ -60,7 +62,7 @@ class Footer(collections.namedtuple('Footer', ['crc', 'terminator'])):
 
     @staticmethod
     def generate(payload):
-        crc = CRCCCITT().calculate(payload)
+        crc = crc_checker.calc(payload)
         terminator = Footer.TERMINATOR
         return Footer(crc, terminator)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyCRC >= 1.21
+crccheck >= 0.6

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,15 @@ from setuptools import setup
 VERSION = '1.0.5'
 
 setup(
-  name = 'pyvesc',
-  packages = ['pyvesc', 'pyvesc.packet', 'pyvesc.messages'],
-  version = VERSION,
-  description = 'Python implementation of the VESC communication protocol.',
-  author = 'Liam Bindle',
-  author_email = 'liambindle@gmail.com',
-  url = 'https://github.com/LiamBindle/PyVESC',
-  download_url = 'https://github.com/LiamBindle/PyVESC/tarball/' + VERSION,
-  keywords = ['vesc', 'VESC', 'communication', 'protcol', 'packet'],
-  classifiers = [],
-  install_requires = ['PyCRC']
+  name='pyvesc',
+  packages=['pyvesc', 'pyvesc.packet', 'pyvesc.messages'],
+  version=VERSION,
+  description='Python implementation of the VESC communication protocol.',
+  author='Liam Bindle',
+  author_email='liambindle@gmail.com',
+  url='https://github.com/LiamBindle/PyVESC',
+  download_url='https://github.com/LiamBindle/PyVESC/tarball/' + VERSION,
+  keywords=['vesc', 'VESC', 'communication', 'protcol', 'packet'],
+  classifiers=[],
+  install_requires=['crccheck']
 )


### PR DESCRIPTION
First of all, very nice job with this library.

I have added a class VESCMotor that is specifically for controlling a BLDC or whatever with a VESC. This does not break or change anything from the existing library. For the class to work, one needs pyserial, but I made this a non-required dependency so someone may still use this just for its message wrapping capabilities.

Updates to the actual existing library include:
- changed PyCRC to crccheck because it does not seem like PyCRC is available anymore.
- updated GetValues for newest firmware (I kept old firmware values in the library and they can still be set if necessary as I do in the init function of the VESCMotor class).
- fixed an issue during msg creation where can_id wasn't getting assigned to the proper object.
- added a check for applying a scalar using a scalar of 0 to mean don't apply a scalar. This allows for printing an error message if there actually is an error.

Anyway, the intent is to make this a more drop in usable library with a VESC for us amateur enthusiasts. ;) See the added motor example script. I think many more people will use this nice library and contribute if we can add the VESCMotor to the documentation so it looks as easy as it is (Not sure how to go about editing the documentation).

Thoughts for the future: Move existing getters and setters to be under VESCMotor only since they only apply to a VESC device instead of the generalized message-making library that you've written.