### PR TITLE
Fixing context manager for VESC

### DIFF
--- a/pyvesc/VESC/VESC.py
+++ b/pyvesc/VESC/VESC.py
@@ -49,6 +49,9 @@ class VESC(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop_heartbeat()
+        if self.serial_port.is_open:
+            self.serial_port.flush()
+            self.serial_port.close()
 
     def _heartbeat_cmd_func(self):
         """


### PR DESCRIPTION
Serial port needs to be closed when VESC context manager exits. I added a small bit of code to check if the port is still open (to handle edge cases), flush the port, and then close it.