### PR TITLE
Fixes forward CAN messages, allows multiple heartbeats, allows **kwards info functions

### DIFF
--- a/pyvesc/VESC/VESC.py
+++ b/pyvesc/VESC/VESC.py
@@ -28,7 +28,9 @@ class VESC(object):
         if has_sensor:
             self.serial_port.write(encode(SetRotorPositionMode(SetRotorPositionMode.DISP_POS_OFF)))
 
-        self.heart_beat_thread = threading.Thread(target=self._heartbeat_cmd_func)
+        self.heart_beat_thread = {
+            None: threading.Thread(target=self._heartbeat_cmd_func)
+        }
         self._stop_heartbeat = threading.Event()
 
         if start_heartbeat:
@@ -53,28 +55,36 @@ class VESC(object):
             self.serial_port.flush()
             self.serial_port.close()
 
-    def _heartbeat_cmd_func(self):
+    def _heartbeat_cmd_func(self, alive_msg):
         """
         Continuous function calling that keeps the motor alive
         """
-        while not self._stop_heartbeat.isSet():
+        while not self._stop_heartbeat.is_set():
             time.sleep(0.1)
             self.write(alive_msg)
 
-    def start_heartbeat(self):
+    def start_heartbeat(self, can_id=None):
         """
         Starts a repetitive calling of the last set cmd to keep the motor alive.
+
+        Args:
+            can_id: Optional, used to specify the CAN ID to start the heartbeat
         """
-        self.heart_beat_thread.start()
+        if can_id not in self.heart_beat_thread:
+            self.heart_beat_thread[can_id] = threading.Thread(target=self._heartbeat_cmd_func, args=(encode(Alive(can_id=can_id)), ))
+        self.heart_beat_thread[can_id].start()
 
     def stop_heartbeat(self):
         """
         Stops the heartbeat thread and resets the last cmd function. THIS MUST BE CALLED BEFORE THE OBJECT GOES OUT OF
         SCOPE UNLESS WRAPPING IN A WITH STATEMENT (Assuming the heartbeat was started).
+
+        This stops all heartbeat threads if multiple are called
         """
-        if self.heart_beat_thread.is_alive():
-            self._stop_heartbeat.set()
-            self.heart_beat_thread.join()
+        self._stop_heartbeat.set()
+        for can_id in self.heart_beat_thread:
+            if self.heart_beat_thread[can_id].is_alive():
+                self.heart_beat_thread[can_id].join()
 
     def write(self, data, num_read_bytes=None):
         """
@@ -91,30 +101,30 @@ class VESC(object):
             response, consumed = decode(self.serial_port.read(self.serial_port.in_waiting))
             return response
 
-    def set_rpm(self, new_rpm):
+    def set_rpm(self, new_rpm, **kwargs):
         """
         Set the electronic RPM value (a.k.a. the RPM value of the stator)
         :param new_rpm: new rpm value
         """
-        self.write(encode(SetRPM(new_rpm)))
+        self.write(encode(SetRPM(new_rpm, **kwargs)))
 
-    def set_current(self, new_current):
+    def set_current(self, new_current, **kwargs):
         """
         :param new_current: new current in milli-amps for the motor
         """
-        self.write(encode(SetCurrent(new_current)))
+        self.write(encode(SetCurrent(new_current, **kwargs)))
 
-    def set_duty_cycle(self, new_duty_cycle):
+    def set_duty_cycle(self, new_duty_cycle, **kwargs):
         """
         :param new_duty_cycle: Value of duty cycle to be set (range [-1e5, 1e5]).
         """
-        self.write(encode(SetDutyCycle(new_duty_cycle)))
+        self.write(encode(SetDutyCycle(new_duty_cycle, **kwargs)))
 
-    def set_servo(self, new_servo_pos):
+    def set_servo(self, new_servo_pos, **kwargs):
         """
         :param new_servo_pos: New servo position. valid range [0, 1]
         """
-        self.write(encode(SetServoPosition(new_servo_pos)))
+        self.write(encode(SetServoPosition(new_servo_pos, **kwargs)))
 
     def get_measurements(self):
         """

--- a/pyvesc/VESC/messages/setters.py
+++ b/pyvesc/VESC/messages/setters.py
@@ -49,7 +49,7 @@ class SetCurrentBrake(metaclass=VESCMessage):
 
 class SetPosition(metaclass=VESCMessage):
     """Set the rotor angle based off of an encoder or sensor
-    
+
     :ivar pos: Value to set the current position or angle to.
     """
     id = VedderCmd.COMM_SET_POS
@@ -98,6 +98,3 @@ class Alive(metaclass=VESCMessage):
     id = VedderCmd.COMM_ALIVE
     fields = []
 
-
-# statically save this message because it does not need to be recalculated
-alive_msg = encode(Alive())

--- a/pyvesc/protocol/base.py
+++ b/pyvesc/protocol/base.py
@@ -14,7 +14,7 @@ class VESCMessage(type):
     _endian_fmt = '!'
     _id_fmt = 'B'
     _can_id_fmt = 'BB'
-    _comm_forward_can = 33
+    _comm_forward_can = 34
     _entry_msg_registry = None
 
     def __init__(cls, name, bases, clsdict):


### PR DESCRIPTION
This PR fixes/changes the following:
- Fixes the forward CAN message, which is actually 34, not 33
  - this might have been caused by the main firmware having all commands in an enum without assigning values, which was fixed in https://github.com/vedderb/bldc/pull/631
- Adds an optional command to `start_heartbeat` to add a CAN-Forward heartbeat signal to the existing heartbeat thread
- Allowed optional arguments for `set_rpm, set_current, set_duty_cycle, set_servo` to be passed to the message constructor, so one is able to call them with a `can_id=xx` argument to forward a message with the above functions